### PR TITLE
fix(reader): stabilize paginated reading position

### DIFF
--- a/app/src/main/java/com/aryan/reader/epubreader/EpubReaderScreen.kt
+++ b/app/src/main/java/com/aryan/reader/epubreader/EpubReaderScreen.kt
@@ -1356,11 +1356,42 @@ fun EpubReaderHost(
     val latestChapterIndex by rememberUpdatedState(currentChapterIndex)
 
     val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner, webViewRefForTts) {
+    DisposableEffect(lifecycleOwner, webViewRefForTts, currentRenderMode, paginator) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_PAUSE) {
-                Timber.d("ON_PAUSE detected. Requesting final CFI for robust save.")
-                webViewRefForTts?.evaluateJavascript("javascript:CfiBridge.onCfiExtracted(window.getCurrentCfi());", null)
+                when (currentRenderMode) {
+                    RenderMode.VERTICAL_SCROLL -> {
+                        Timber.d("ON_PAUSE detected. Requesting final CFI for robust save.")
+                        webViewRefForTts?.evaluateJavascript("javascript:CfiBridge.onCfiExtracted(window.getCurrentCfi());", null)
+                    }
+                    RenderMode.PAGINATED -> {
+                        scope.launch {
+                            val pageToSave = paginatedPagerState.currentPage
+                            val bookPaginator = paginator as? BookPaginator
+                            val locator = bookPaginator?.getLocatorForPage(pageToSave)
+                            val chapterIndex = bookPaginator?.findChapterIndexForPage(pageToSave)
+
+                            if (locator != null && chapterIndex != null) {
+                                val progress = if (totalBookLengthChars > 0) {
+                                    val completedCharsInPreviousChapters = chapters.take(chapterIndex).sumOf { it.plainTextContent.length.toLong() }
+                                    val currentPageInChapter = pageToSave - (bookPaginator.chapterStartPageIndices[chapterIndex] ?: 0)
+                                    val charsScrolledInCurrentChapter = bookPaginator.getCharactersScrolledInChapter(chapterIndex, currentPageInChapter)
+                                    val totalCharsScrolled = completedCharsInPreviousChapters + charsScrolledInCurrentChapter
+                                    val calculatedProgress = ((totalCharsScrolled.toDouble() / totalBookLengthChars.toDouble()) * 100.0).toFloat()
+                                    val isLastPageOfBook = pageToSave == paginatedPagerState.pageCount - 1
+                                    if (isLastPageOfBook) 100f else calculatedProgress
+                                } else {
+                                    0f
+                                }
+                                lastKnownLocator = locator
+                                Timber.d("ON_PAUSE saving paginated position. Page: $pageToSave, Locator: $locator, Progress: $progress%")
+                                onSavePosition(locator, null, progress)
+                            } else {
+                                Timber.w("ON_PAUSE paginated save failed. Locator or chapter index was null.")
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/com/aryan/reader/paginatedreader/BookPaginator.kt
+++ b/app/src/main/java/com/aryan/reader/paginatedreader/BookPaginator.kt
@@ -841,12 +841,18 @@ class BookPaginator(
         return Jsoup.parse(htmlToParse).body().text()
     }
 
-    private fun calculateAccurateStartIndex(targetChapterIndex: Int): Int {
+    private suspend fun ensureAccurateStartIndex(targetChapterIndex: Int): Int {
         if (targetChapterIndex <= 0) {
             return 0
         }
-        val startIndex = chapterStartPageIndices[targetChapterIndex] ?: 0
-        return startIndex
+
+        for (chapterIndex in 0 until targetChapterIndex) {
+            if (!finalizedChapterCounts.contains(chapterIndex)) {
+                paginateChapter(chapterIndex)
+            }
+        }
+
+        return chapterStartPageIndices[targetChapterIndex] ?: 0
     }
 
     override fun findPageForAnchor(
@@ -858,7 +864,7 @@ class BookPaginator(
             Timber.tag("TOC_NAV_DEBUG").d("Precision nav request for anchor: '$anchor'")
 
             if (anchor.isNullOrBlank()) {
-                val start = chapterStartPageIndices[chapterIndex] ?: 0
+                val start = ensureAccurateStartIndex(chapterIndex)
                 withContext(Dispatchers.Main) { onResult(start) }
                 return@launch
             }
@@ -874,9 +880,9 @@ class BookPaginator(
                 chapterIndex to null
             }
 
-            // 2. ENSURE PAGINATION: Get pages for the determined chapter
+            // 2. ENSURE PAGINATION: Resolve the chapter start after earlier chapters have real page counts.
+            val chapterStartPage = ensureAccurateStartIndex(targetChapter)
             val chapterPages = pageCache[targetChapter] ?: paginateChapter(targetChapter)
-            val chapterStartPage = chapterStartPageIndices[targetChapter] ?: 0
 
             if (chapterPages == null) {
                 withContext(Dispatchers.Main) { onResult(chapterStartPage) }
@@ -971,8 +977,8 @@ class BookPaginator(
                 return@launch
             }
 
+            val chapterStartPage = ensureAccurateStartIndex(targetChapterIndex)
             val chapterPages = pageCache[targetChapterIndex] ?: paginateChapter(targetChapterIndex)
-            val chapterStartPage = calculateAccurateStartIndex(targetChapterIndex)
 
             if (chapterPages == null) {
                 Timber.e("Href Navigation failed: Could not paginate target chapter $targetChapterIndex.")
@@ -1004,8 +1010,8 @@ class BookPaginator(
             val targetChapterIndex = result.locationInSource
             Timber.i("Finding page for search result: '${result.query}' in chapter $targetChapterIndex")
 
+            val chapterStartPage = ensureAccurateStartIndex(targetChapterIndex)
             val chapterPages = pageCache[targetChapterIndex] ?: paginateChapter(targetChapterIndex)
-            val chapterStartPage = calculateAccurateStartIndex(targetChapterIndex)
 
             if (chapterPages == null) {
                 Timber.e("Search result navigation failed: Could not paginate target chapter $targetChapterIndex.")
@@ -1082,8 +1088,8 @@ class BookPaginator(
         val targetChapterIndex = locator.chapterIndex
         Timber.tag("POS_DIAG").d("findPageForLocator: Searching for $locator")
 
+        val chapterStartPage = ensureAccurateStartIndex(targetChapterIndex)
         val chapterPages = pageCache[targetChapterIndex] ?: paginateChapter(targetChapterIndex)
-        val chapterStartPage = chapterStartPageIndices[targetChapterIndex] ?: 0
 
         Timber.tag("POS_DIAG").d("findPageForLocator: targetChapterIndex=$targetChapterIndex, chapterStartPage=$chapterStartPage, chapterPages.size=${chapterPages?.size}")
 
@@ -1182,8 +1188,8 @@ class BookPaginator(
         coroutineScope.launch(Dispatchers.IO) {
             Timber.i("findPageForCfi: Starting search for CFI: '$cfi' in chapter: '$chapterIndex'")
 
+            val chapterStartPage = ensureAccurateStartIndex(chapterIndex)
             val chapterPages = pageCache[chapterIndex] ?: paginateChapter(chapterIndex)
-            val chapterStartPage = calculateAccurateStartIndex(chapterIndex)
             Timber.d("findPageForCfi: Chapter $chapterIndex starts at absolute page $chapterStartPage.")
 
             if (chapterPages == null) {


### PR DESCRIPTION
Paginated locations could be resolved against estimated chapter starts while earlier chapters were still being repaginated, so restoring a saved locator or choosing a chapter could land several pages early.

Page-target lookups now finalize the preceding chapter counts before computing an absolute page, and paginated mode saves its current locator on lifecycle pause instead of relying on the vertical WebView CFI path.

Verification: attempted `bash ./gradlew :app:compileDebugKotlin`, but this machine has no Java runtime installed.

Fixes #200