### PR TITLE
Support erasing with stylus button

### DIFF
--- a/app/src/main/java/com/aryan/reader/pdf/PdfPageComposable.kt
+++ b/app/src/main/java/com/aryan/reader/pdf/PdfPageComposable.kt
@@ -539,6 +539,7 @@ internal fun PdfPageComposable(
     isActivePage: Boolean = true,
     isBubbleZoomModeActive: Boolean = false,
     isStylusOnlyMode: Boolean = false,
+    stylusButtonHovering: Boolean = false,
     isAutoScrollPlaying: Boolean = false,
     isHighlighterSnapEnabled: Boolean = false,
     userHighlights: List<PdfUserHighlight> = emptyList(),
@@ -3335,7 +3336,7 @@ internal fun PdfPageComposable(
                             "Page $pageIndex | Type: ${down.type} | isPrimary: ${buttons.isPrimaryPressed} | isSecondary: ${buttons.isSecondaryPressed} | isTertiary: ${buttons.isTertiaryPressed} | buttonsString: $buttons"
                         )
 
-                        val isEraserOverride = down.type == PointerType.Eraser || (down.type == PointerType.Stylus && currentEvent.buttons.isSecondaryPressed)
+                        val isEraserOverride = down.type == PointerType.Eraser || (down.type == PointerType.Stylus && (currentEvent.buttons.isSecondaryPressed || currentEvent.buttons.isPrimaryPressed || stylusButtonHovering))
                         isStylusEraserOverride = isEraserOverride
 
                         val dragPointerId = down.id

--- a/app/src/main/java/com/aryan/reader/pdf/PdfVerticalReader.kt
+++ b/app/src/main/java/com/aryan/reader/pdf/PdfVerticalReader.kt
@@ -242,6 +242,7 @@ internal fun PdfVerticalReader(
     autoScrollSpeed: Float = 1.0f,
     onInteractionListener: () -> Unit = {},
     isStylusOnlyMode: Boolean = false,
+    stylusButtonHovering: Boolean = false,
     isHighlighterSnapEnabled: Boolean = false,
     userHighlights: List<PdfUserHighlight> = emptyList(),
     onHighlightAdd: (Int, Pair<Int, Int>, String, PdfHighlightColor) -> Unit = { _,_,_,_ -> },
@@ -994,7 +995,7 @@ internal fun PdfVerticalReader(
                 )
 
                 val isEraserOverride = down.type == PointerType.Eraser ||
-                        (down.type == PointerType.Stylus && currentEvent.buttons.isSecondaryPressed)
+                        (down.type == PointerType.Stylus && (currentEvent.buttons.isSecondaryPressed || currentEvent.buttons.isPrimaryPressed || stylusButtonHovering))
                 isStylusEraserOverride = isEraserOverride
 
                 fun getPageAndPoint(screenOffset: Offset): Pair<Int, PdfPoint>? {
@@ -1730,6 +1731,7 @@ internal fun PdfVerticalReader(
                                     selectedTool = selectedTool,
                                     richTextController = richTextController,
                                     isStylusOnlyMode = isStylusOnlyMode,
+                                    stylusButtonHovering = stylusButtonHovering,
                                     isAutoScrollPlaying = isAutoScrollPlaying,
                                     textBoxes = textBoxes.filter { it.pageIndex == page.index },
                                     selectedTextBoxId = selectedTextBoxId,

--- a/app/src/main/java/com/aryan/reader/pdf/PdfViewerScreen.kt
+++ b/app/src/main/java/com/aryan/reader/pdf/PdfViewerScreen.kt
@@ -3491,6 +3491,7 @@ fun PdfViewerScreen(
         Scaffold(
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
         ) { _ ->
+            var stylusButtonHovering by remember { mutableStateOf(false) }
             BoxWithConstraints(
                 modifier = Modifier
                     .fillMaxSize()
@@ -3508,6 +3509,9 @@ fun PdfViewerScreen(
                                                     "tertiary=${buttons.isTertiaryPressed}, back=${buttons.isBackPressed}, " +
                                                     "forward=${buttons.isForwardPressed}"
                                         )
+                                        if (!change.pressed) {
+                                            stylusButtonHovering = buttons.isPrimaryPressed || buttons.isSecondaryPressed
+                                        }
                                     }
                                 }
                             }
@@ -3914,6 +3918,7 @@ fun PdfViewerScreen(
                                                 },
                                                 richTextController = richTextController,
                                                 isStylusOnlyMode = isStylusOnlyMode,
+                                                stylusButtonHovering = stylusButtonHovering,
                                                 isAutoScrollPlaying = isAutoScrollPlaying,
                                                 isHighlighterSnapEnabled = isHighlighterSnapEnabled,
                                                 isEditMode = isDrawingActive,
@@ -4321,6 +4326,7 @@ fun PdfViewerScreen(
                                             selectedTool = selectedTool,
                                             richTextController = richTextController,
                                             isStylusOnlyMode = isStylusOnlyMode,
+                                            stylusButtonHovering = stylusButtonHovering,
                                             isEditMode = isDrawingActive,
                                             textBoxes = textBoxes,
                                             selectedTextBoxId = selectedTextBoxId,


### PR DESCRIPTION
This PR fixes the stylus barrel button not activating eraser on Samsung devices.

On Samsung tablets, the S Pen barrel button is only reported in hover events (stylus above screen, `pressed=false`). By the time the tip actually touches the screen, the button state is gone from the event. The existing code checked for the button at touch time and therefore never saw it.

This PR tracks button state during hover in the GlobalPointer handler in `PdfViewerScreen`, and carries it forward as a `stylusButtonHovering` flag into `PdfVerticalReader` and `PdfPageComposable`. When a touch arrives, this flag is included alongside `isPrimaryPressed` and `isSecondaryPressed` in the `isEraserOverride` check, covering Samsung's behavior as well as devices that do report button state at touch time or use a different button mapping.
