### PR TITLE
fix(webview): gate setWebContentsDebuggingEnabled on BuildConfig.DEBUG and drop unused allowFileAccess in MathMLRenderer

### DIFF
--- a/app/src/main/java/com/aryan/reader/MainActivity.kt
+++ b/app/src/main/java/com/aryan/reader/MainActivity.kt
@@ -121,7 +121,9 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
-        WebView.setWebContentsDebuggingEnabled(true)
+        if (BuildConfig.DEBUG) {
+            WebView.setWebContentsDebuggingEnabled(true)
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/com/aryan/reader/paginatedreader/MathMLRenderer.kt
+++ b/app/src/main/java/com/aryan/reader/paginatedreader/MathMLRenderer.kt
@@ -29,6 +29,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.aryan.reader.BuildConfig
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
@@ -75,12 +76,13 @@ class MathMLRenderer(private val context: Context) {
 
     private fun setupWebView() {
         try {
-            WebView.setWebContentsDebuggingEnabled(true)
+            if (BuildConfig.DEBUG) {
+                WebView.setWebContentsDebuggingEnabled(true)
+            }
 
             webView = WebView(context).apply {
                 @SuppressLint("SetJavaScriptEnabled")
                 settings.javaScriptEnabled = true
-                settings.allowFileAccess = true
                 settings.domStorageEnabled = true
                 addJavascriptInterface(WebAppInterface { svg ->
                     completeCurrentJob(RenderResult.Success(svg))


### PR DESCRIPTION
Closes #302.

The app has three WebView setup paths. `MyApplication.onCreate` already gates `setWebContentsDebuggingEnabled` correctly:

```kotlin
if (BuildConfig.DEBUG) {
    Timber.plant(Timber.DebugTree())
    WebView.setWebContentsDebuggingEnabled(true)
}
```

The other two paths were missing the guard. This PR brings them in line.

### Changes

**`MainActivity.kt`**

The last line of `onCreate` was an unconditional `WebView.setWebContentsDebuggingEnabled(true)`. Since `setWebContentsDebuggingEnabled` is a process-wide static, a release build would leave every WebView the app spawns afterwards inspectable from `chrome://inspect`. Wrapped in the same `if (BuildConfig.DEBUG)` gate `MyApplication` uses.

**`MathMLRenderer.kt`**

Same fix for the `setWebContentsDebuggingEnabled(true)` call at the start of `setupWebView()`.

While there, drop `settings.allowFileAccess = true`. The renderer only ever loads `file:///android_asset/MathML-template.html`, and the `android_asset` scheme is permitted on every supported Android version even when `setAllowFileAccess(false)` is in force. With JS enabled and a JS bridge attached (`AndroidBridge`), the flag adds attack surface for no functional benefit.

### What is intentionally untouched

`ChapterWebView` keeps `settings.allowFileAccess = true`. The custom-font path renders `@font-face src: url('file://<path>')` against a user-picked font on device storage, which genuinely needs the flag.